### PR TITLE
Add menu with "Log out" button to profile icon

### DIFF
--- a/client/Nav.jsx
+++ b/client/Nav.jsx
@@ -4,6 +4,10 @@ import PropTypes from 'prop-types';
 
 import { post } from 'utils.js';
 
+import OButton from 'oasisui/OButton.jsx';
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
+
 import 'Nav.css';
 
 function focusSearch(el, e) {
@@ -33,6 +37,7 @@ function Nav({ searchUpdate }) {
   const inputRef = useRef(null);
   const [query, setQuery] = useState('');
   const [searchFocused, setSearchFocused] = useState('');
+  const [anchorEl, setAnchorEl] = useState('');
 
   const updateQuery = useCallback(e => {
     const query = e.target.value;
@@ -63,6 +68,14 @@ function Nav({ searchUpdate }) {
     };
   }, [inputRef.current]);
 
+    const handleClick = event => {
+      setAnchorEl(event.currentTarget);
+    };
+
+    const handleClose = () => {
+      setAnchorEl(null);
+    };
+
   return (
     <>
       <nav className="nav__container">
@@ -87,9 +100,20 @@ function Nav({ searchUpdate }) {
             src="/svg/search.svg"
           />
         </form>
-        <a className="nav__profile" href="#" onClick={signOut}>
+
+        <a className="nav__profile" href="#" onClick={handleClick}>
           <img src="/svg/profile.svg" />
         </a>
+        <Menu
+          id="simple-menu"
+          anchorEl={anchorEl}
+          keepMounted
+          open={Boolean(anchorEl)}
+          onClose={handleClose}
+        >
+          <MenuItem onClick={signOut}>Logout</MenuItem>
+        </Menu>
+
       </nav>
       <div className="nav__overlay" />
     </>


### PR DESCRIPTION
Instead of just clicking the profile icon in the top right to log out, which is surprising behaviour, I added a menu with one item (eventually will also have a "Profile" button to see the user's profile) so it's clear that clicking that button will log you out.

Profile icon:
<img width="217" alt="Screen Shot 2020-03-09 at 10 28 30 PM" src="https://user-images.githubusercontent.com/10877343/76273863-5a99ea00-6255-11ea-816a-021d49dc227f.png">
After clicking profile icon:
<img width="248" alt="Screen Shot 2020-03-09 at 10 28 36 PM" src="https://user-images.githubusercontent.com/10877343/76273861-5a015380-6255-11ea-9477-6e60a8bf1c19.png">
